### PR TITLE
Fix query parameter key

### DIFF
--- a/goweather.go
+++ b/goweather.go
@@ -17,7 +17,7 @@ func main() {
 
 	arg := os.Args[1]
 
-	url := fmt.Sprintf("http://api.openweathermap.org/data/2.5/weather?q=%s&units=imperial", url.QueryEscape(arg))
+	url := fmt.Sprintf("http://api.openweathermap.org/data/2.5/weather?zip=%s&units=imperial", url.QueryEscape(arg))
 
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
Was wondering why my weather data was off and did some looking into the API documentation. The `q` param looks for city name instead of zip code. Somehow my zip code matched a city in Estonia.

We could also check the type and choose the right query param based on user input.
